### PR TITLE
Fixes issue#68

### DIFF
--- a/src/adj_list.cpp
+++ b/src/adj_list.cpp
@@ -834,7 +834,6 @@ std::vector<node> AdjList::get_out_nodes(node_id_t node_id)
 {
     std::vector<node> out_nodes;
     WT_CURSOR *outadj_cursor = get_out_adjlist_cursor();
-    WT_CURSOR *n_cursor = get_node_cursor();
     if (!has_node(node_id))
     {
         throw GraphException("There is no node with ID " + to_string(node_id));
@@ -843,12 +842,9 @@ std::vector<node> AdjList::get_out_nodes(node_id_t node_id)
 
     for (auto dst_id : adjlist)
     {
-        n_cursor->set_key(n_cursor, dst_id);
-        node found = {0};
-        if (n_cursor->search(n_cursor) == 0)
+        node found = get_node(dst_id);
+        if (found.id != 0)
         {
-            CommonUtil::__record_to_node(n_cursor, &found, opts.read_optimize);
-            found.id = dst_id;
             out_nodes.push_back(found);
         }
         else
@@ -860,7 +856,6 @@ std::vector<node> AdjList::get_out_nodes(node_id_t node_id)
         }
     }
     out_adjlist_cursor->reset(out_adjlist_cursor);
-    n_cursor->reset(n_cursor);
     return out_nodes;
 }
 
@@ -943,7 +938,6 @@ std::vector<node> AdjList::get_in_nodes(node_id_t node_id)
 {
     std::vector<node> in_nodes;
     WT_CURSOR *inadj_cursor = get_in_adjlist_cursor();
-    WT_CURSOR *n_cursor = get_node_cursor();
     if (!has_node(node_id))
     {
         throw GraphException("There is no node with ID " + to_string(node_id));
@@ -952,11 +946,9 @@ std::vector<node> AdjList::get_in_nodes(node_id_t node_id)
     node found = {0};
     for (auto src_id : adjlist)
     {
-        n_cursor->set_key(n_cursor, src_id);
-        if (n_cursor->search(n_cursor) == 0)
+        node found = get_node(src_id);
+        if (found.id != 0)
         {
-            CommonUtil::__record_to_node(n_cursor, &found, opts.read_optimize);
-            found.id = src_id;
             in_nodes.push_back(found);
         }
         else
@@ -968,7 +960,6 @@ std::vector<node> AdjList::get_in_nodes(node_id_t node_id)
         }
     }
     inadj_cursor->reset(inadj_cursor);
-    n_cursor->reset(n_cursor);
     return in_nodes;
 }
 

--- a/src/adj_list.cpp
+++ b/src/adj_list.cpp
@@ -835,7 +835,10 @@ std::vector<node> AdjList::get_out_nodes(node_id_t node_id)
     std::vector<node> out_nodes;
     WT_CURSOR *outadj_cursor = get_out_adjlist_cursor();
     WT_CURSOR *n_cursor = get_node_cursor();
-
+    if (!has_node(node_id))
+    {
+        throw GraphException("There is no node with ID " + to_string(node_id));
+    }
     std::vector<node_id_t> adjlist = get_adjlist(outadj_cursor, node_id);
 
     for (auto dst_id : adjlist)
@@ -856,7 +859,36 @@ std::vector<node> AdjList::get_out_nodes(node_id_t node_id)
                                  " but not in node table");
         }
     }
+    out_adjlist_cursor->reset(out_adjlist_cursor);
+    n_cursor->reset(n_cursor);
     return out_nodes;
+}
+
+/**
+ * @brief Get a list of ids of nodes that have an incoming edge from node_id
+ * (are out nodes for node_id); does one less cursor search than get_out_nodes
+ *
+ * @param node_id The node which is being queried.
+ * @return std::vector<node> The vector of out nodes
+ * @throws GraphException if could not acquire cursors to node table or the
+ * out_adjlist tables;
+ */
+std::vector<node_id_t> AdjList::get_out_nodes_id(node_id_t node_id)
+{
+    std::vector<node_id_t> out_nodes_id;
+    WT_CURSOR *outadj_cursor = get_out_adjlist_cursor();
+    if (!has_node(node_id))
+    {
+        throw GraphException("There is no node with ID " + to_string(node_id));
+    }
+    std::vector<node_id_t> adjlist = get_adjlist(outadj_cursor, node_id);
+
+    for (auto dst_id : adjlist)
+    {
+        out_nodes_id.push_back(dst_id);
+    }
+    out_adjlist_cursor->reset(out_adjlist_cursor);
+    return out_nodes_id;
 }
 
 /**
@@ -872,7 +904,10 @@ std::vector<edge> AdjList::get_out_edges(node_id_t node_id)
     std::vector<node_id_t> dst_nodes;
     WT_CURSOR *out_adj_cur = get_out_adjlist_cursor();
     WT_CURSOR *e_cur = get_edge_cursor();
-
+    if (!has_node(node_id))
+    {
+        throw GraphException("There is no node with ID " + to_string(node_id));
+    }
     dst_nodes = get_adjlist(out_adj_cur, node_id);
 
     for (auto dst : dst_nodes)
@@ -909,7 +944,10 @@ std::vector<node> AdjList::get_in_nodes(node_id_t node_id)
     std::vector<node> in_nodes;
     WT_CURSOR *inadj_cursor = get_in_adjlist_cursor();
     WT_CURSOR *n_cursor = get_node_cursor();
-
+    if (!has_node(node_id))
+    {
+        throw GraphException("There is no node with ID " + to_string(node_id));
+    }
     std::vector<node_id_t> adjlist = get_adjlist(inadj_cursor, node_id);
     node found = {0};
     for (auto src_id : adjlist)
@@ -929,7 +967,36 @@ std::vector<node> AdjList::get_in_nodes(node_id_t node_id)
                                  " but not in node table");
         }
     }
+    inadj_cursor->reset(inadj_cursor);
+    n_cursor->reset(n_cursor);
     return in_nodes;
+}
+
+/**
+ * @brief Get a list of ids of nodes that have an outgoing edge to node_id (are
+ * in nodes for node_id); does one less cursor search than get_in_nodes
+ *
+ * @param node_id The node which is being queried.
+ * @return std::vector<node> the vector of in nodes
+ * @throws GraphException if could not acquire cursors to node table or the
+ * in_adjlist tables
+ */
+std::vector<node_id_t> AdjList::get_in_nodes_id(node_id_t node_id)
+{
+    std::vector<node_id_t> in_nodes_id;
+    WT_CURSOR *inadj_cursor = get_in_adjlist_cursor();
+    if (!has_node(node_id))
+    {
+        throw GraphException("There is no node with ID " + to_string(node_id));
+    }
+    std::vector<node_id_t> adjlist = get_adjlist(inadj_cursor, node_id);
+    node found = {0};
+    for (auto src_id : adjlist)
+    {
+        in_nodes_id.push_back(src_id);
+    }
+    inadj_cursor->reset(inadj_cursor);
+    return in_nodes_id;
 }
 
 /**

--- a/src/adj_list.h
+++ b/src/adj_list.h
@@ -414,8 +414,10 @@ class AdjList : public GraphBase
     std::vector<edge> get_edges();
     std::vector<edge> get_out_edges(node_id_t node_id);
     std::vector<node> get_out_nodes(node_id_t node_id);
+    std::vector<node_id_t> get_out_nodes_id(node_id_t node_id);
     std::vector<edge> get_in_edges(node_id_t node_id);
     std::vector<node> get_in_nodes(node_id_t node_id);
+    std::vector<node_id_t> get_in_nodes_id(node_id_t node_id);
     std::string get_db_name() const { return opts.db_name; };
     std::vector<node_id_t> get_adjlist(WT_CURSOR *cursor, node_id_t node_id);
     OutCursor *get_outnbd_iter();

--- a/src/edgekey.cpp
+++ b/src/edgekey.cpp
@@ -838,7 +838,6 @@ std::vector<node> EdgeKey::get_out_nodes(node_id_t node_id)
 {
     std::vector<node> out_nodes;
     WT_CURSOR *src_cur = get_src_idx_cursor();
-    WT_CURSOR *e_cur = get_edge_cursor();
 
     if (!has_node(node_id))
     {
@@ -864,11 +863,9 @@ std::vector<node> EdgeKey::get_out_nodes(node_id_t node_id)
             }
             else
             {
-                e_cur->set_key(e_cur, dst, OutOfBand_ID);
-                if (e_cur->search(e_cur) == 0)
+                node found = get_node(dst);
+                if (found.id != 0)
                 {
-                    node found{.id = dst};
-                    CommonUtil::__record_to_node_ekey(e_cur, &found);
                     out_nodes.push_back(found);
                 }
             }
@@ -878,7 +875,6 @@ std::vector<node> EdgeKey::get_out_nodes(node_id_t node_id)
                               // next entry the cursor points to to see if it
                               // has a (node_id, <dst>) entry.
     }
-    e_cur->reset(e_cur);
     src_cur->reset(src_cur);
     return out_nodes;
 }
@@ -982,7 +978,6 @@ std::vector<edge> EdgeKey::get_in_edges(node_id_t node_id)
 std::vector<node> EdgeKey::get_in_nodes(node_id_t node_id)
 {
     std::vector<node> in_nodes;
-    WT_CURSOR *e_cur = get_edge_cursor();
     WT_CURSOR *dst_cur = get_dst_idx_cursor();
 
     if (!has_node(node_id))
@@ -1000,12 +995,10 @@ std::vector<node> EdgeKey::get_in_nodes(node_id_t node_id)
 
         do
         {
-            e_cur->set_key(e_cur, src_id, OutOfBand_ID);
-            if (e_cur->search(e_cur) == 0)
+            node found = get_node(src_id);
+            if (found.id != 0)
             {
-                node found{.id = src_id};
-                CommonUtil::__record_to_node_ekey(e_cur, &found);
-                in_nodes.push_back(found);
+                in_nodes.push_back(get_node(src_id));
             }
             if (dst_cur->next(dst_cur) == 0)
             {
@@ -1021,7 +1014,6 @@ std::vector<node> EdgeKey::get_in_nodes(node_id_t node_id)
 
         } while (dst_id == node_id);
     }
-    e_cur->reset(e_cur);
     dst_cur->reset(dst_cur);
     return in_nodes;
 }

--- a/src/edgekey.h
+++ b/src/edgekey.h
@@ -530,8 +530,10 @@ class EdgeKey : public GraphBase
     std::vector<edge> get_edges();
     std::vector<edge> get_out_edges(node_id_t node_id);
     std::vector<node> get_out_nodes(node_id_t node_id);
+    std::vector<node_id_t> get_out_nodes_id(node_id_t node_id);
     std::vector<edge> get_in_edges(node_id_t node_id);
     std::vector<node> get_in_nodes(node_id_t node_id);
+    std::vector<node_id_t> get_in_nodes_id(node_id_t node_id);
 
     OutCursor *get_outnbd_iter();
     InCursor *get_innbd_iter();

--- a/src/graph.h
+++ b/src/graph.h
@@ -38,8 +38,10 @@ class GraphBase
     virtual degree_t get_in_degree(node_id_t node_id) = 0;           // ✅
     virtual std::vector<edge> get_out_edges(node_id_t node_id) = 0;  // ✅
     virtual std::vector<node> get_out_nodes(node_id_t node_id) = 0;  // ✅
-    virtual std::vector<edge> get_in_edges(node_id_t node_id) = 0;   // ✅
-    virtual std::vector<node> get_in_nodes(node_id_t node_id) = 0;   // ✅
+    virtual std::vector<node_id_t> get_out_nodes_id(node_id_t node_id) = 0;
+    virtual std::vector<edge> get_in_edges(node_id_t node_id) = 0;  // ✅
+    virtual std::vector<node> get_in_nodes(node_id_t node_id) = 0;  // ✅
+    virtual std::vector<node_id_t> get_in_nodes_id(node_id_t node_id) = 0;
     void close();
     uint64_t get_num_nodes();
     uint64_t get_num_edges();

--- a/src/standard_graph.h
+++ b/src/standard_graph.h
@@ -197,6 +197,7 @@ class StdOutCursor : public OutCursor
 {
     bool data_remaining = true;
     node_id_t next_expected = 0;
+
    public:
     StdOutCursor(WT_CURSOR *cur, WT_SESSION *sess) : OutCursor(cur, sess) {}
 
@@ -508,8 +509,10 @@ class StandardGraph : public GraphBase
     std::vector<edge> get_edges();
     std::vector<edge> get_out_edges(node_id_t node_id);
     std::vector<node> get_out_nodes(node_id_t node_id);
+    std::vector<node_id_t> get_out_nodes_id(node_id_t node_id);
     std::vector<edge> get_in_edges(node_id_t node_id);
     std::vector<node> get_in_nodes(node_id_t node_id);
+    std::vector<node_id_t> get_in_nodes_id(node_id_t node_id);
     void get_nodes(vector<node> &nodes);
     std::string get_db_name() const { return opts.db_name; };
 

--- a/test/test_adj_list.cpp
+++ b/test/test_adj_list.cpp
@@ -257,20 +257,39 @@ void test_get_out_nodes(AdjList graph)
     INFO();
     int test_id1 = 1, test_id2 = 4, test_id3 = 1500;
     std::vector<node> nodes = graph.get_out_nodes(test_id1);
+    std::vector<node_id_t> nodes_id = graph.get_out_nodes_id(test_id1);
     assert(nodes.size() == 3);
+    assert(nodes_id.size() == 3);
     assert(nodes.at(0).id == SampleGraph::node2.id);  // edge(1->2)
+    assert(nodes.at(0).id == nodes_id.at(0));
     assert(nodes.at(1).id == SampleGraph::node3.id);  // edge(1->3)
+    assert(nodes.at(1).id == nodes_id.at(1));
     assert(nodes.at(2).id == SampleGraph::node7.id);  // edge(1->7)
+    assert(nodes.at(2).id == nodes_id.at(2));
 
     // test for a node that has no out-edge
     nodes = graph.get_out_nodes(test_id2);
+    nodes_id = graph.get_out_nodes_id(test_id2);
     assert(nodes.size() == 0);
+    assert(nodes_id.size() == 0);
 
     // test for a node that does not exist
     bool assert_fail = false;
     try
     {
         nodes = graph.get_out_nodes(test_id3);
+    }
+    catch (GraphException &ex)
+    {
+        cout << ex.what() << endl;
+        assert_fail = true;
+    }
+    assert(assert_fail);
+
+    assert_fail = false;
+    try
+    {
+        nodes_id = graph.get_out_nodes_id(test_id3);
     }
     catch (GraphException &ex)
     {
@@ -285,19 +304,37 @@ void test_get_in_nodes(AdjList graph)
     INFO();
     int test_id1 = 3, test_id2 = 4, test_id3 = 1500;
     std::vector<node> nodes = graph.get_in_nodes(test_id1);
+    std::vector<node_id_t> nodes_id = graph.get_in_nodes_id(test_id1);
     assert(nodes.size() == 2);
+    assert(nodes_id.size() == 2);
     assert(nodes.at(0).id == SampleGraph::node1.id);
+    assert(nodes.at(0).id == nodes_id.at(0));
     assert(nodes.at(1).id == SampleGraph::node2.id);
+    assert(nodes.at(1).id == nodes_id.at(1));
 
     // test for a node that has no in_edge
     nodes = graph.get_in_nodes(test_id2);
+    nodes_id = graph.get_in_nodes_id(test_id2);
     assert(nodes.size() == 0);
+    assert(nodes_id.size() == 0);
 
     // test for a node that does not exist
     bool assert_fail = false;
     try
     {
         nodes = graph.get_in_nodes(test_id3);
+    }
+    catch (GraphException &ex)
+    {
+        cout << ex.what() << endl;
+        assert_fail = true;
+    }
+    assert(assert_fail);
+
+    assert_fail = false;
+    try
+    {
+        nodes_id = graph.get_in_nodes_id(test_id3);
     }
     catch (GraphException &ex)
     {

--- a/test/test_edgekey.cpp
+++ b/test/test_edgekey.cpp
@@ -468,12 +468,12 @@ int main()
     test_delete_node(graph, opts.is_directed);
     // // test_delete_isolated_node(graph, opts.is_directed);
 
-    // test_InCursor(graph);
-    // test_OutCursor(graph);
-    // test_NodeCursor(graph);
-    // test_NodeCursor_Range(graph);
-    // test_EdgeCursor(graph);
-    // test_EdgeCursor_Range(graph);
+    test_InCursor(graph);
+    test_OutCursor(graph);
+    test_NodeCursor(graph);
+    test_NodeCursor_Range(graph);
+    test_EdgeCursor(graph);
+    test_EdgeCursor_Range(graph);
 
     tearDown(graph);
 }

--- a/test/test_edgekey.cpp
+++ b/test/test_edgekey.cpp
@@ -171,13 +171,20 @@ void test_get_out_nodes(EdgeKey graph)
 {
     INFO();
     std::vector<node> nodes = graph.get_out_nodes(1);
+    std::vector<node_id_t> nodes_id = graph.get_out_nodes_id(1);
     assert(nodes.size() == 3);
+    assert(nodes_id.size() == 3);
     assert(nodes.at(0).id == SampleGraph::node2.id);  // edge(1->2)
+    assert(nodes.at(0).id == nodes_id.at(0));
     assert(nodes.at(1).id == SampleGraph::node3.id);  // edge(1->3)
+    assert(nodes.at(1).id == nodes_id.at(1));
     assert(nodes.at(2).id == SampleGraph::node7.id);  // edge(1->7)
+    assert(nodes.at(2).id == nodes_id.at(2));
     // test for a node that has no out-edge
     nodes = graph.get_out_nodes(4);
+    nodes_id = graph.get_out_nodes_id(4);
     assert(nodes.size() == 0);
+    assert(nodes_id.size() == 0);
 
     // test for a node that does not exist
     bool assert_fail = false;
@@ -227,13 +234,19 @@ void test_get_in_nodes(EdgeKey graph)
 {
     INFO();
     std::vector<node> nodes = graph.get_in_nodes(3);
+    std::vector<node_id_t> nodes_id = graph.get_in_nodes_id(3);
     assert(nodes.size() == 2);
+    assert(nodes_id.size() == 2);
     assert(nodes.at(0).id == SampleGraph::node1.id);
+    assert(nodes.at(0).id == nodes_id.at(0));
     assert(nodes.at(1).id == SampleGraph::node2.id);
+    assert(nodes.at(1).id == nodes_id.at(1));
 
     // test for a node that has no in_edge
     nodes = graph.get_in_nodes(4);
+    nodes_id = graph.get_in_nodes_id(4);
     assert(nodes.size() == 0);
+    assert(nodes_id.size() == 0);
 
     // test for a node that does not exist
     bool assert_fail = false;
@@ -455,12 +468,12 @@ int main()
     test_delete_node(graph, opts.is_directed);
     // // test_delete_isolated_node(graph, opts.is_directed);
 
-    test_InCursor(graph);
-    test_OutCursor(graph);
-    test_NodeCursor(graph);
-    test_NodeCursor_Range(graph);
-    test_EdgeCursor(graph);
-    test_EdgeCursor_Range(graph);
+    // test_InCursor(graph);
+    // test_OutCursor(graph);
+    // test_NodeCursor(graph);
+    // test_NodeCursor_Range(graph);
+    // test_EdgeCursor(graph);
+    // test_EdgeCursor_Range(graph);
 
     tearDown(graph);
 }

--- a/test/test_standard_graph.cpp
+++ b/test/test_standard_graph.cpp
@@ -186,50 +186,147 @@ void test_get_nodes(StandardGraph graph)
     }
 }
 
-void test_get_in_nodes_and_edges(StandardGraph graph, bool is_directed)
+void test_get_out_edges(StandardGraph graph)
 {
     INFO();
-    vector<edge> got_e = graph.get_in_edges(3);
-    vector<node> got_n = graph.get_in_nodes(3);
-    if (is_directed)
+    int test_id1 = 1, test_id2 = 4, test_id3 = 1500;
+    std::vector<edge> edges = graph.get_out_edges(test_id1);
+    assert(edges.size() == 3);
+    // compare edge0
+    assert(edges.at(0).src_id == SampleGraph::edge1.src_id);
+    assert(edges.at(0).dst_id == SampleGraph::edge1.dst_id);
+    // compare edge1
+    assert(edges.at(1).src_id == SampleGraph::edge2.src_id);
+    assert(edges.at(1).dst_id == SampleGraph::edge2.dst_id);
+    // compare edge4
+    assert(edges.at(2).src_id == SampleGraph::edge4.src_id);
+    assert(edges.at(2).dst_id == SampleGraph::edge4.dst_id);
+
+    // Now test for a node that has no out edge
+    edges = graph.get_out_edges(test_id2);
+    assert(edges.size() == 0);
+
+    // Now try getting out edges for a node that does not exist
+    bool assert_fail = false;
+    try
     {
-        assert(got_e.size() == 2);
-        assert(got_n.size() == 2);
+        edges = graph.get_out_edges(test_id3);
     }
-    else
+    catch (GraphException &ex)
     {
-        assert(got_e.size() == 2);
-        assert(got_n.size() == 2);
+        cout << ex.what() << endl;
+        assert_fail = true;
     }
-    assert(graph.get_in_degree(3) == got_n.size());
-    assert(graph.get_in_degree(3) == got_e.size());
+    assert(assert_fail);
 }
 
-void test_get_out_nodes_and_edges(StandardGraph graph, bool is_directed)
+void test_get_out_nodes(StandardGraph graph)
 {
     INFO();
-    vector<edge> got_e = graph.get_out_edges(3);
-    vector<node> got_n = graph.get_out_nodes(3);
-    if (!is_directed)
-    {
-        assert(got_e.size() == 2);
-        assert(got_n.size() == 2);
-    }
-    else
-    {
-        assert(got_e.size() == 0);
-        assert(got_n.size() == 0);
-    }
+    int test_id1 = 1, test_id2 = 4, test_id3 = 1500;
+    std::vector<node> nodes = graph.get_out_nodes(test_id1);
+    std::vector<node_id_t> nodes_id = graph.get_out_nodes_id(test_id1);
+    assert(nodes.size() == 3);
+    assert(nodes_id.size() == 3);
+    assert(nodes.at(0).id == SampleGraph::node2.id);  // edge(1->2)
+    assert(nodes.at(0).id == nodes_id.at(0));
+    assert(nodes.at(1).id == SampleGraph::node3.id);  // edge(1->3)
+    assert(nodes.at(1).id == nodes_id.at(1));
+    assert(nodes.at(2).id == SampleGraph::node7.id);  // edge(1->7)
+    assert(nodes.at(2).id == nodes_id.at(2));
 
-    for (edge x : got_e)
-    {
-        CommonUtil::dump_edge(x);
-    }
+    // test for a node that has no out-edge
+    nodes = graph.get_out_nodes(test_id2);
+    nodes_id = graph.get_out_nodes_id(test_id2);
+    assert(nodes.size() == 0);
+    assert(nodes_id.size() == 0);
 
-    for (node x : got_n)
+    // test for a node that does not exist
+    bool assert_fail = false;
+    try
     {
-        CommonUtil::dump_node(x);
+        nodes = graph.get_out_nodes(test_id3);
     }
+    catch (GraphException &ex)
+    {
+        cout << ex.what() << endl;
+        assert_fail = true;
+    }
+    assert(assert_fail);
+
+    assert_fail = false;
+    try
+    {
+        nodes_id = graph.get_out_nodes_id(test_id3);
+    }
+    catch (GraphException &ex)
+    {
+        cout << ex.what() << endl;
+        assert_fail = true;
+    }
+    assert(assert_fail);
+}
+
+void test_get_in_nodes(StandardGraph graph)
+{
+    INFO();
+    std::vector<node> nodes = graph.get_in_nodes(3);
+    std::vector<node_id_t> nodes_id = graph.get_in_nodes_id(3);
+    assert(nodes.size() == 2);
+    assert(nodes_id.size() == 2);
+    assert(nodes.at(0).id == SampleGraph::node1.id);
+    assert(nodes.at(0).id == nodes_id.at(0));
+    assert(nodes.at(1).id == SampleGraph::node2.id);
+    assert(nodes.at(1).id == nodes_id.at(1));
+
+    // test for a node that has no in_edge
+    nodes = graph.get_in_nodes(4);
+    nodes_id = graph.get_in_nodes_id(4);
+    assert(nodes.size() == 0);
+    assert(nodes_id.size() == 0);
+
+    // test for a node that does not exist
+    bool assert_fail = false;
+    try
+    {
+        nodes = graph.get_in_nodes(1500);
+    }
+    catch (GraphException &ex)
+    {
+        cout << ex.what() << endl;
+        assert_fail = true;
+    }
+    assert(assert_fail);
+}
+
+void test_get_in_edges(StandardGraph graph)
+{
+    INFO();
+    std::vector<edge> edges = graph.get_in_edges(3);
+    assert(edges.size() == 2);
+    // Check edge0
+    assert(edges.at(0).src_id == SampleGraph::edge2.src_id);
+    assert(edges.at(0).dst_id == SampleGraph::edge2.dst_id);
+    // Check edge1
+    assert(edges.at(1).src_id == SampleGraph::edge3.src_id);
+    assert(edges.at(1).dst_id == SampleGraph::edge3.dst_id);
+
+    // now test for a node that has no in-edge
+    edges = graph.get_in_edges(4);
+    assert(edges.size() == 0);
+
+    // Now try getting in edges for a node that does not exist.
+    bool assert_fail = false;
+    try
+    {
+        edges = graph.get_out_edges(1500);
+    }
+    catch (GraphException &ex)
+    {
+        cout << ex.what() << endl;
+        assert_fail = true;
+    }
+    assert(assert_fail);
 }
 
 void test_cursor(StandardGraph graph)
@@ -473,11 +570,13 @@ int main()
     // test_cursor(graph);
 
     // test get_in_nodes_and_edges
-    test_get_in_nodes_and_edges(graph, opts.is_directed);
+    test_get_in_edges(graph);
+    test_get_in_nodes(graph);
     print_delim();
 
     // test get_out_nodes_and_edges
-    test_get_out_nodes_and_edges(graph, opts.is_directed);
+    test_get_out_edges(graph);
+    test_get_out_nodes(graph);
     print_delim();
 
     // Test deleting a node


### PR DESCRIPTION
1. Unified behavior of the 3 implementations of get_out/in_nodes 
2. Implemented get_out/in_nodes_id, which only returns vector of ids and uses 1 less cursor search than the function that actually gets the node object, fixes #68
3. Changed tests to test & reflect the changes