### PR TITLE
FIxed restoring the num_nodes and num_edges from DB

### DIFF
--- a/benchmark/bc_parallel.cpp
+++ b/benchmark/bc_parallel.cpp
@@ -62,7 +62,7 @@ void PBFS(GraphEngine &graph_engine,
                         path_counts[v] += path_counts[u];
                     }
                 }
-                g_->close();
+                g_->close(false);
             }
             lqueue.flush();
 #pragma omp barrier
@@ -145,7 +145,7 @@ pvector<ScoreT> Brandes(GraphEngine &graph_engine,
                 }
                 deltas[u] = delta_u;
                 scores[u] += delta_u;
-                g_->close();
+                g_->close(false);
             }
         }
         t.stop();
@@ -244,7 +244,7 @@ int main(int argc, char *argv[])
 
     node_id_t maxNodeID = graph->get_max_node_id();
     node_id_t num_edges = graph->get_num_edges();
-    graph->close();
+    graph->close(false);
 
     long double total_time = 0;
     sssp_info info(0);

--- a/benchmark/bfs.cpp
+++ b/benchmark/bfs.cpp
@@ -127,6 +127,6 @@ int main(int argc, char *argv[])
                        time_from_outside,
                        opts.stat_log);
     }
-    graph->close();
+    graph->close(false);
     graphEngine.close_graph();
 }

--- a/benchmark/bfs_parallel.cpp
+++ b/benchmark/bfs_parallel.cpp
@@ -81,7 +81,7 @@ int64_t BUStep(GraphEngine *graph_engine,
             }
             in_cursor->next(&found);
         }
-        graph->close();
+        graph->close(false);
     }
 
     return awake_count;
@@ -113,7 +113,7 @@ int64_t TDStep(GraphEngine *graph_engine,
                     }
                 }
             }
-            graph->close();
+            graph->close(false);
         }
         lqueue.flush();
     }
@@ -152,7 +152,7 @@ void BitmapToQueue(GraphEngine *graph_engine,
                 if (bm.get_bit(found.id)) lqueue.push_back(found.id);
                 node_cursor->next(&found);
             }
-            graph->close();
+            graph->close(false);
         }
         lqueue.flush();
     }
@@ -181,7 +181,7 @@ pvector<NodeID> InitParent(GraphEngine *graph_engine,
                                    : -1;
             node_cursor->next(&found);
         }
-        graph->close();
+        graph->close(false);
     }
     return parent;
 }
@@ -264,7 +264,7 @@ pvector<NodeID> DOBFS(GraphEngine *graph_engine,
     for (node_id_t n = 0; n < num_nodes; n++)
         if (parent[n] < -1) parent[n] = -1;
 
-    graph_stat->close();
+    graph_stat->close(false);
     return parent;
 }
 
@@ -293,7 +293,7 @@ int main(int argc, char *argv[])
     node_id_t num_nodes = g->get_num_nodes();
     node_id_t max_node_id = g->get_max_node_id();
     node source = g->get_random_node();
-    g->close();
+    g->close(false);
     DOBFS(&graphEngine, source.id, num_nodes, max_node_id, THREAD_NUM, 15, 18);
     t.stop();
     std::cout << "BFS completed in " << t.t_micros() << std::endl;

--- a/benchmark/cc_parallel.cpp
+++ b/benchmark/cc_parallel.cpp
@@ -78,7 +78,7 @@ pvector<node_id_t> ShiloachVishkin(GraphEngine& g,
             }
             out_nbd_cur->close();
             delete out_nbd_cur;
-            graph->close();
+            graph->close(false);
         }
 #pragma omp parallel for
         for (node_id_t n = 0; n < maxNodeID; n++)
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
     GraphBase* graph = graphEngine.create_graph_handle();
     node_id_t numNodes = graph->get_num_nodes();
     node_id_t maxNodeID = graph->get_max_node_id();
-    graph->close();
+    graph->close(false);
 
     t.stop();
     std::cout << "Graph loaded in " << t.t_micros() << std::endl;

--- a/benchmark/pagerank.cpp
+++ b/benchmark/pagerank.cpp
@@ -138,6 +138,6 @@ int main(int argc, char *argv[])
     pagerank(*graph, opts, opts.iterations, opts.tolerance, opts.stat_log);
     t.stop();
     cout << "PR  completed in : " << t.t_micros() << endl;
-    graph->close();
+    graph->close(false);
     graphEngine.close_graph();
 }

--- a/benchmark/pagerank_iter_map.cpp
+++ b/benchmark/pagerank_iter_map.cpp
@@ -132,6 +132,6 @@ int main(int argc, char *argv[])
     pagerank(graph, opts, opts.iterations, opts.tolerance, opts.stat_log);
     t.stop();
     cout << "PR  completed in : " << t.t_micros() << endl;
-    graph->close();
+    graph->close(false);
     graphEngine.close_graph();
 }

--- a/benchmark/pagerank_vc.cpp
+++ b/benchmark/pagerank_vc.cpp
@@ -41,7 +41,7 @@ pvector<ScoreT> pagerank(GraphEngine& graph_engine,
             node_cursor->next(&found);
         }
         node_cursor->close();
-        graph->close();
+        graph->close(false);
     }
 
     for (int iter = 0; iter < max_iters; iter++)
@@ -75,7 +75,7 @@ pvector<ScoreT> pagerank(GraphEngine& graph_engine,
             }
 
             in_cursor->close();
-            graph->close();
+            graph->close(false);
         }
         printf(" %2d    %lf\n", iter, error);
         if (error < epsilon) break;
@@ -142,7 +142,7 @@ int main(int argc, char* argv[])
 
     cmdline_opts opts = pr_cli.get_parsed_opts();
     opts.stat_log += "/" + opts.db_name;
-
+    //    opts.print_config("out");
     const int THREAD_NUM = omp_get_max_threads();
     Times t;
     t.start();
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
         GraphBase* g = graphEngine.create_graph_handle();
         node_id_t num_nodes = g->get_num_nodes();
         node_id_t max_node_id = g->get_max_node_id();
-        g->close();
+        g->close(false);
         pvector<ScoreT> score = pagerank(graphEngine,
                                          THREAD_NUM,
                                          opts.iterations,

--- a/benchmark/sssp.cpp
+++ b/benchmark/sssp.cpp
@@ -106,7 +106,7 @@ int main(int argc, char *argv[])
     std::cout << "Average time taken for " << opts.num_trials
               << " trials: " << total_time / opts.num_trials << std::endl;
 
-    graph->close();
+    graph->close(false);
     graphEngine.close_graph();
     return 0;
 }

--- a/benchmark/sssp_parallel.cpp
+++ b/benchmark/sssp_parallel.cpp
@@ -129,7 +129,7 @@ pvector<edgeweight_t> DeltaStep(GraphEngine &graph_engine,
         {
             cout << "took " << iter << " iterations" << endl;
         }
-        graph->close();
+        graph->close(false);
     }
     return dist;
 }
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
 
     node_id_t maxNodeID = graph->get_max_node_id();
     node_id_t num_edges = graph->get_num_edges();
-    graph->close();
+    graph->close(false);
 
     long double total_time = 0;
     sssp_info info(0);

--- a/benchmark/tc.cpp
+++ b/benchmark/tc.cpp
@@ -141,6 +141,6 @@ int main(int argc, char *argv[])
 
         print_csv_info(opts.db_name, info, opts.stat_log);
     }
-    graph->close();
+    graph->close(false);
     graphEngine.close_graph();
 }

--- a/benchmark/tc_iter.cpp
+++ b/benchmark/tc_iter.cpp
@@ -80,7 +80,7 @@ int64_t trust_tc_iter(GraphEngine &graph_engine)
             out_cursor->next(&found);
         }
         out_cursor->close();
-        graph->close();
+        graph->close(false);
         delete out_cursor;
     }
 

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -230,9 +230,9 @@ int GraphBase::_get_table_cursor(const std::string &table,
     return 0;
 }
 
-void GraphBase::close()
+void GraphBase::close(bool synchronize)
 {
-    sync_metadata();
+    if (synchronize) sync_metadata();
     int ret = session->close(session, nullptr);
     if (ret != 0)
     {
@@ -276,10 +276,12 @@ void GraphBase::_restore_from_db()
         else if (key == MetadataKey::num_nodes)
         {
             this->opts.num_nodes = *((node_id_t *)item.data);
+            GraphBase::local_nnodes.store(this->opts.num_nodes);
         }
         else if (key == MetadataKey::num_edges)
         {
             this->opts.num_edges = *((uint64_t *)item.data);
+            GraphBase::local_nedges.store(this->opts.num_edges);
         }
     }
 }
@@ -326,10 +328,12 @@ void GraphBase::_restore_from_db(const std::string &db_name)
         else if (key == MetadataKey::num_nodes)
         {
             this->opts.num_nodes = *((node_id_t *)item.data);
+            GraphBase::local_nnodes.store(this->opts.num_nodes);
         }
         else if (key == MetadataKey::num_edges)
         {
             this->opts.num_edges = *((uint64_t *)item.data);
+            GraphBase::local_nedges.store(this->opts.num_edges);
         }
     }
 }

--- a/src/graph.h
+++ b/src/graph.h
@@ -61,7 +61,7 @@ class GraphBase
 
     // void set_locks(LockSet *locks_ptr);
 
-    void close();
+    void close(bool synchronize = false);
     virtual node_id_t get_max_node_id() = 0;
     virtual node_id_t get_min_node_id() = 0;
 

--- a/src/graph_engine.h
+++ b/src/graph_engine.h
@@ -112,7 +112,7 @@ void GraphEngine::calculate_thread_offsets(bool make_edge)
     GraphBase *graph_stats = create_graph_handle();
     _calculate_thread_offsets(num_threads, graph_stats);
     if (make_edge) _calculate_thread_offsets_edge(num_threads, graph_stats);
-    graph_stats->close();
+    graph_stats->close(false);
 }
 
 /**

--- a/test/test_adj_list.cpp
+++ b/test/test_adj_list.cpp
@@ -612,7 +612,7 @@ void test_EdgeCursor_Range(AdjList graph)
     edge_cursor->close();
     delete edge_cursor;
 }
-void tearDown(AdjList &graph) { graph.close(); }
+void tearDown(AdjList &graph) { graph.close(true); }
 
 int main()
 {

--- a/test/test_concurrency.cpp
+++ b/test/test_concurrency.cpp
@@ -38,7 +38,7 @@ int main()
     GraphBase* graph = myEngine.create_graph_handle();
     graph->add_node(node{.id = 0});
     graph->add_node(node{.id = 100});
-    graph->close();
+    graph->close(true);
 #pragma omp parallel for
     for (int i = 0; i < THREAD_NUM; i++)
     {
@@ -67,7 +67,7 @@ int main()
             ret = -1;
             while (ret != 0) ret = graph->add_edge(edge{5, 8}, false);
         }
-        graph->close();
+        graph->close(true);
     }
 
     GraphBase* report = myEngine.create_graph_handle();

--- a/test/test_edgekey.cpp
+++ b/test/test_edgekey.cpp
@@ -332,7 +332,7 @@ void test_get_in_and_out_degree(EdgeKey &graph)
     assert(outdeg == 3);
 }
 
-void tearDown(EdgeKey &graph) { graph.close(); }
+void tearDown(EdgeKey &graph) { graph.close(true); }
 
 void test_InCursor(EdgeKey &graph)
 {

--- a/test/test_partition.cpp
+++ b/test/test_partition.cpp
@@ -8,7 +8,7 @@
 
 #define INFO() fprintf(stderr, "Now running: %s\n", __FUNCTION__);
 
-void tearDown(GraphBase *graph) { graph->close(); }
+void tearDown(GraphBase *graph) { graph->close(true); }
 
 void test_get_nodes(GraphBase *graph) { INFO(); }
 

--- a/test/test_standard_graph.cpp
+++ b/test/test_standard_graph.cpp
@@ -54,7 +54,7 @@ void create_init_nodes(StandardGraph &graph, bool is_directed)
     assert(edge_cnt == SampleGraph::test_edges.size());
 }
 
-void tearDown(StandardGraph &graph) { graph.close(); }
+void tearDown(StandardGraph &graph) { graph.close(true); }
 
 void test_node_add(StandardGraph &graph, bool read_optimize)
 {


### PR DESCRIPTION
the restored num_nodes and num_edges were not being properly restored, which led to a divide-by-zero error in the benchmark. fixed that. 